### PR TITLE
Do not silently remove info, instead point to our admin contact address

### DIFF
--- a/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-nodeinfo
+++ b/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-nodeinfo
@@ -10,4 +10,4 @@ echo 'Access-Control-Allow-Origin: *'
 
 batctl if | cut -d: -f1 | grep -qxF "$QUERY_STRING" || badrequest
 
-exec /usr/bin/gluon-neighbour-info -s neighbour -i "$QUERY_STRING" -d ff02::2:1001 -p 1001 -r nodeinfo | sed 's/"owner":{"contact":"[^"]*"},//'
+exec /usr/bin/gluon-neighbour-info -s neighbour -i "$QUERY_STRING" -d ff02::2:1001 -p 1001 -r nodeinfo | sed 's/"owner":{"contact":"[^"]*"},/"owner":{"contact":"Bitte schreibe eine Mail an technik@freifunk-aachen.de, wenn du Kontakt zu diesem Knotenbetreiber aufnehmen möchtest!"},/'

--- a/files/lib/gluon/status-page/www/cgi-bin/nodeinfo
+++ b/files/lib/gluon/status-page/www/cgi-bin/nodeinfo
@@ -5,4 +5,4 @@ Access-Control-Allow-Origin: *
 Content-type: application/json
 
 EOF
-exec gluon-neighbour-info -d ::1 -p 1001 -t 1 -c 1 -r nodeinfo | sed 's/"owner":{"contact":"[^"]*"},//'
+exec gluon-neighbour-info -d ::1 -p 1001 -t 1 -c 1 -r nodeinfo | sed 's/"owner":{"contact":"[^"]*"},/"owner":{"contact":"Bitte schreibe eine Mail an technik@freifunk-aachen.de, wenn du Kontakt zu diesem Knotenbetreiber aufnehmen möchtest!"},/'


### PR DESCRIPTION
As suggested in the discussion at https://forum.freifunk.net/t/kontaktadresse-eines-knotens-herausfinden/11275/17, we will now provide the administrative contact address instead of just striking the address completely.

Discussion: Maybe we should shorten this to something like `Chiffre: technik@freifunk-aachen.de` which brings the point across as well? Or even something like `Chiffre: technik+$HOSTNAME@freifunk-aachen.de`?
